### PR TITLE
Remove user id from signup response & use sign up validations (merge after #10)

### DIFF
--- a/backend/db/repository.go
+++ b/backend/db/repository.go
@@ -8,7 +8,7 @@ import (
 )
 
 type UserRepository interface {
-	AddUser(ctx context.Context, user domain.User) (int64, error)
+	AddUser(ctx context.Context, user domain.User) (error)
 	GetUser(ctx context.Context, id int64) (domain.User, error)
 	UpdateBalance(ctx context.Context, id int64, balance int64) error
 }
@@ -21,16 +21,13 @@ func NewUserRepository(db *sql.DB) UserRepository {
 	return &UserDBRepository{DB: db}
 }
 
-func (r *UserDBRepository) AddUser(ctx context.Context, user domain.User) (int64, error) {
+func (r *UserDBRepository) AddUser(ctx context.Context, user domain.User) (error) {
 	if _, err := r.ExecContext(ctx, "INSERT INTO users (name, password) VALUES (?, ?)", user.Name, user.Password); err != nil {
-		return 0, err
+		return err
 	}
 	// TODO: if other insert query is executed at the same time, it might return wrong id
 	// http.StatusConflict(409) 既に同じIDがあった場合
-	row := r.QueryRowContext(ctx, "SELECT id FROM users WHERE rowid = LAST_INSERT_ROWID()")
-
-	var id int64
-	return id, row.Scan(&id)
+	return nil
 }
 
 func (r *UserDBRepository) GetUser(ctx context.Context, id int64) (domain.User, error) {

--- a/backend/domain/user.go
+++ b/backend/domain/user.go
@@ -1,8 +1,23 @@
 package domain
 
+import (
+	"errors"
+	"strings"
+)
+
 type User struct {
 	ID       int64
 	Password string
 	Name     string
 	Balance  int64
+}
+
+func (u User) Validate() error {
+	u.Name = strings.TrimSpace(u.Name) 
+
+	if u.Name == "" {
+		return errors.New("Username is empty or contains only spaces")
+	}
+
+	return nil
 }

--- a/frontend/simple-mercari-web/src/components/Signup/Signup.tsx
+++ b/frontend/simple-mercari-web/src/components/Signup/Signup.tsx
@@ -1,18 +1,15 @@
-import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { useCookies } from "react-cookie";
-import { toast } from "react-toastify";
-import { fetcher } from "../../helper";
+import React, { useState } from "react"
+import { useNavigate } from "react-router-dom"
+import { toast } from "react-toastify"
+import { fetcher } from "../../helper"
 
 export const Signup = () => {
-  const [name, setName] = useState<string>();
-  const [password, setPassword] = useState<string>();
-  const [userID, setUserID] = useState<number>();
-  const [_, setCookie] = useCookies(["userID"]);
+  const [name, setName] = useState<string>()
+  const [password, setPassword] = useState<string>()
 
-  const navigate = useNavigate();
+  const navigate = useNavigate()
   const onSubmit = (_: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    fetcher<{ id: number; name: string }>(`/register`, {
+    fetcher<{ name: string }>(`/register`, {
       method: "POST",
       headers: {
         Accept: "application/json",
@@ -24,17 +21,15 @@ export const Signup = () => {
       }),
     })
       .then((user) => {
-        toast.success("New account is created!");
-        console.log("POST success:", user.id);
-        setCookie("userID", user.id);
-        setUserID(user.id);
-        navigate("/");
+        toast.success(`New account with name: ${user.name} has been created!`)
+        console.log("POST success:", user.name)
+        navigate("/")
       })
       .catch((err) => {
-        console.log(`POST error:`, err);
-        toast.error(err.message);
-      });
-  };
+        console.log(`POST error:`, err)
+        toast.error("Sign Up Failed")
+      })
+  }
 
   return (
     <div>
@@ -46,7 +41,7 @@ export const Signup = () => {
           id="MerTextInput"
           placeholder="name"
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-            setName(e.target.value);
+            setName(e.target.value)
           }}
           required
         />
@@ -57,16 +52,13 @@ export const Signup = () => {
           id="MerTextInput"
           placeholder="password"
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-            setPassword(e.target.value);
+            setPassword(e.target.value)
           }}
         />
         <button onClick={onSubmit} id="MerButton">
           Signup
         </button>
-        {userID ? (
-          <p>Use "{userID}" as UserID for login</p>
-        ) : null}
       </div>
     </div>
-  );
-};
+  )
+}


### PR DESCRIPTION
Changes:

- Removed `userId` from backend sign up response to reduce load on backend (hopefully)
- Removed unnecessary use of `userId` on sign up page
- Used `user` domain validations to validate user name before it is added to db