### PR TITLE
Backend: refactor /item endpoint to return ALL items

### DIFF
--- a/backend/db/repository.go
+++ b/backend/db/repository.go
@@ -56,7 +56,7 @@ type ItemRepository interface {
 	AddItem(ctx context.Context, item domain.Item) (domain.Item, error)
 	GetItem(ctx context.Context, id int32) (domain.Item, error)
 	GetItemImage(ctx context.Context, id int32) ([]byte, error)
-	GetOnSaleItems(ctx context.Context) ([]domain.Item, error)
+	GetAllItems(ctx context.Context) ([]domain.Item, error)
 	GetItemsByKeyword(ctx context.Context, keyword string) ([]domain.Item, error)
 	GetItemsByUserID(ctx context.Context, userID int64) ([]domain.Item, error)
 	GetCategory(ctx context.Context, id int64) (domain.Category, error)
@@ -97,8 +97,8 @@ func (r *ItemDBRepository) GetItemImage(ctx context.Context, id int32) ([]byte, 
 	return image, row.Scan(&image)
 }
 
-func (r *ItemDBRepository) GetOnSaleItems(ctx context.Context) ([]domain.Item, error) {
-	rows, err := r.QueryContext(ctx, "SELECT * FROM items WHERE status = ? ORDER BY updated_at desc", domain.ItemStatusOnSale)
+func (r *ItemDBRepository) GetAllItems(ctx context.Context) ([]domain.Item, error) {
+	rows, err := r.QueryContext(ctx, "SELECT * FROM items ORDER BY updated_at desc")
 	if err != nil {
 		return nil, err
 	}

--- a/backend/handler/handler.go
+++ b/backend/handler/handler.go
@@ -39,21 +39,6 @@ type registerRequest struct {
 type registerResponse struct {
 	Name string `json:"name"`
 }
-
-type getUserItemsResponse struct {
-	ID           int32  `json:"id"`
-	Name         string `json:"name"`
-	Price        int64  `json:"price"`
-	CategoryName string `json:"category_name"`
-}
-
-type getOnSaleItemsResponse struct {
-	ID           int32  `json:"id"`
-	Name         string `json:"name"`
-	Price        int64  `json:"price"`
-	CategoryName string `json:"category_name"`
-}
-
 type getItemsResponse struct {
 	ID           int32  			`json:"id"`
 	Name         string 			`json:"name"`
@@ -297,17 +282,17 @@ func (h *Handler) Sell(c echo.Context) error {
 	return c.JSON(http.StatusOK, "successful")
 }
 
-func (h *Handler) GetOnSaleItems(c echo.Context) error {
+func (h *Handler) GetAllItems(c echo.Context) error {
 	ctx := c.Request().Context()
 
-	items, err := h.ItemRepo.GetOnSaleItems(ctx)
+	items, err := h.ItemRepo.GetAllItems(ctx)
 	// TODO: not found handling
 	// http.StatusNotFound(404)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusNotFound, err)
 	}
 
-	var res []getOnSaleItemsResponse
+	var res []getItemsResponse
 	for _, item := range items {
 		cats, err := h.ItemRepo.GetCategories(ctx)
 		if err != nil {
@@ -315,7 +300,7 @@ func (h *Handler) GetOnSaleItems(c echo.Context) error {
 		}
 		for _, cat := range cats {
 			if cat.ID == item.CategoryID {
-				res = append(res, getOnSaleItemsResponse{ID: item.ID, Name: item.Name, Price: item.Price, CategoryName: cat.Name})
+				res = append(res, getItemsResponse{ID: item.ID, Name: item.Name, Price: item.Price, CategoryName: cat.Name, Status: item.Status})
 			}
 		}
 	}
@@ -402,7 +387,7 @@ func (h *Handler) GetUserItems(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 
-	var res []getUserItemsResponse
+	var res []getItemsResponse
 	for _, item := range items {
 		cats, err := h.ItemRepo.GetCategories(ctx)
 		if err != nil {
@@ -410,7 +395,7 @@ func (h *Handler) GetUserItems(c echo.Context) error {
 		}
 		for _, cat := range cats {
 			if cat.ID == item.CategoryID {
-				res = append(res, getUserItemsResponse{ID: item.ID, Name: item.Name, Price: item.Price, CategoryName: cat.Name})
+				res = append(res, getItemsResponse{ID: item.ID, Name: item.Name, Price: item.Price, CategoryName: cat.Name, Status: item.Status})
 			}
 		}
 	}

--- a/backend/main.go
+++ b/backend/main.go
@@ -79,7 +79,7 @@ func run(ctx context.Context) int {
 	e.POST("/initialize", h.Initialize)
 	e.GET("/log", h.AccessLog)
 
-	e.GET("/items", h.GetOnSaleItems)
+	e.GET("/items", h.GetAllItems)
 	e.GET("/items/:itemID", h.GetItem)
 	e.GET("/search", h.SearchItems)
 	e.GET("/items/:itemID/image", h.GetImage)

--- a/frontend/simple-mercari-web/src/components/Home/Home.tsx
+++ b/frontend/simple-mercari-web/src/components/Home/Home.tsx
@@ -14,6 +14,7 @@ interface Item {
   name: string
   price: number
   category_name: string
+  status: number
 }
 export const Home = () => {
   const [cookies] = useCookies(["userID", "token"])

--- a/frontend/simple-mercari-web/src/components/Item/Item.tsx
+++ b/frontend/simple-mercari-web/src/components/Item/Item.tsx
@@ -8,6 +8,7 @@ interface Item {
   name: string
   price: number
   category_name: string
+  status: number
 }
 
 export const Item: React.FC<{ item: Item }> = ({ item }) => {

--- a/frontend/simple-mercari-web/src/components/ItemList/ItemList.tsx
+++ b/frontend/simple-mercari-web/src/components/ItemList/ItemList.tsx
@@ -1,14 +1,15 @@
-import React from "react";
-import { Item } from "../Item";
-interface Item {
-  id: number;
-  name: string;
-  price: number;
-  category_name: string;
+import React from "react"
+import { Item } from "../Item"
+interface ItemType {
+  id: number
+  name: string
+  price: number
+  category_name: string
+  status: number
 }
 
 interface Prop {
-  items: Item[];
+  items: ItemType[]
 }
 
 export const ItemList: React.FC<Prop> = (props) => {
@@ -16,8 +17,8 @@ export const ItemList: React.FC<Prop> = (props) => {
     <div>
       {props.items &&
         props.items.map((item) => {
-          return <Item item={item} />;
+          return <Item item={item} />
         })}
     </div>
-  );
-};
+  )
+}

--- a/frontend/simple-mercari-web/src/components/UserProfile/UserProfile.tsx
+++ b/frontend/simple-mercari-web/src/components/UserProfile/UserProfile.tsx
@@ -1,24 +1,25 @@
-import { useState, useEffect } from "react";
-import { useCookies } from "react-cookie";
-import { useParams } from "react-router-dom";
-import { MerComponent } from "../MerComponent";
-import { toast } from "react-toastify";
-import { ItemList } from "../ItemList";
-import { fetcher } from "../../helper";
+import { useState, useEffect } from "react"
+import { useCookies } from "react-cookie"
+import { useParams } from "react-router-dom"
+import { MerComponent } from "../MerComponent"
+import { toast } from "react-toastify"
+import { ItemList } from "../ItemList"
+import { fetcher } from "../../helper"
 
 interface Item {
-  id: number;
-  name: string;
-  price: number;
-  category_name: string;
+  id: number
+  name: string
+  price: number
+  category_name: string
+  status: number
 }
 
 export const UserProfile: React.FC = () => {
-  const [items, setItems] = useState<Item[]>([]);
-  const [balance, setBalance] = useState<number>();
-  const [addedbalance, setAddedBalance] = useState<number>();
-  const [cookies] = useCookies(["token"]);
-  const params = useParams();
+  const [items, setItems] = useState<Item[]>([])
+  const [balance, setBalance] = useState<number>()
+  const [addedbalance, setAddedBalance] = useState<number>()
+  const [cookies] = useCookies(["token"])
+  const params = useParams()
 
   const fetchItems = () => {
     fetcher<Item[]>(`/users/${params.id}/items`, {
@@ -31,10 +32,10 @@ export const UserProfile: React.FC = () => {
     })
       .then((items) => setItems(items))
       .catch((err) => {
-        console.log(`GET error:`, err);
-        toast.error(err.message);
-      });
-  };
+        console.log(`GET error:`, err)
+        toast.error(err.message)
+      })
+  }
 
   const fetchUserBalance = () => {
     fetcher<{ balance: number }>(`/balance`, {
@@ -46,18 +47,18 @@ export const UserProfile: React.FC = () => {
       },
     })
       .then((res) => {
-        setBalance(res.balance);
+        setBalance(res.balance)
       })
       .catch((err) => {
-        console.log(`GET error:`, err);
-        toast.error(err.message);
-      });
-  };
+        console.log(`GET error:`, err)
+        toast.error(err.message)
+      })
+  }
 
   useEffect(() => {
-    fetchItems();
-    fetchUserBalance();
-  }, []);
+    fetchItems()
+    fetchUserBalance()
+  }, [])
 
   const onBalanceSubmit = () => {
     fetcher(`/balance`, {
@@ -73,10 +74,10 @@ export const UserProfile: React.FC = () => {
     })
       .then((_) => window.location.reload())
       .catch((err) => {
-        console.log(`POST error:`, err);
-        toast.error(err.message);
-      });
-  };
+        console.log(`POST error:`, err)
+        toast.error(err.message)
+      })
+  }
 
   return (
     <MerComponent>
@@ -92,7 +93,7 @@ export const UserProfile: React.FC = () => {
               id="MerTextInput"
               placeholder="0"
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                setAddedBalance(Number(e.target.value));
+                setAddedBalance(Number(e.target.value))
               }}
               required
             />
@@ -108,5 +109,5 @@ export const UserProfile: React.FC = () => {
         </div>
       </div>
     </MerComponent>
-  );
-};
+  )
+}


### PR DESCRIPTION
Changes:
Backend:

- Updated repo to return all Items, with `status` both `sold` and `unsold` at endpoint `/items`
- Extended `response` type to include item `status` (so that they can be filtered on frontend in next PR)

Frontend:

- Extended `item` type on several pages to include `status`