### PR TITLE
Frontend: Item filter button implementation

### DIFF
--- a/frontend/simple-mercari-web/src/App.css
+++ b/frontend/simple-mercari-web/src/App.css
@@ -217,13 +217,15 @@ body {
   border-radius: 5%;
 }
 
-.SearchBar {
+.ItemFilter {
   background-color: #222427;
   color: white;
   border-color: #6d757d;
+  width: 20%;
+  margin-bottom: 10px;
 }
 
-.SearchBar:focus {
+.ItemFilter:focus {
   background-color: #222427;
   color: white;
   border-color: #6d757d;

--- a/frontend/simple-mercari-web/src/components/Home/Home.tsx
+++ b/frontend/simple-mercari-web/src/components/Home/Home.tsx
@@ -114,7 +114,7 @@ export const Home = (props: HomeComponentProps) => {
           className="form-control ItemFilter"
           onChange={handleItemFilterChange}
         >
-          <option value="showAll">Show all</option>
+          <option value="showAll">Show All</option>
           <option value="showUnsold">Show Unsold Only</option>
           <option value="showSold">Show Sold Only</option>
         </select>

--- a/frontend/simple-mercari-web/src/components/Home/Home.tsx
+++ b/frontend/simple-mercari-web/src/components/Home/Home.tsx
@@ -1,9 +1,7 @@
-import { Login } from "../Login"
-import { Signup } from "../Signup"
 import { ItemList } from "../ItemList"
 import { useCookies } from "react-cookie"
 import { MerComponent } from "../MerComponent"
-import { useEffect, useState } from "react"
+import { ChangeEvent, useEffect, useState } from "react"
 import { toast } from "react-toastify"
 import { fetcher } from "../../helper"
 import "react-toastify/dist/ReactToastify.css"
@@ -19,15 +17,23 @@ interface HomeComponentProps {
   searchValue: string
 }
 
+type ShowItem = "showAll" | "showSold" | "showUnsold"
+
 export const Home = (props: HomeComponentProps) => {
   const [cookies] = useCookies(["userID", "userName", "token"])
   const [items, setItems] = useState<Item[]>([])
-  const [profile, setProfile] = useState<Item[]>([])
+  const [allItemsReference, setAllItemsReference] = useState<Item[]>([])
+  const [itemFilter, setItemFilter] = useState<ShowItem>("showAll")
 
   const handleSearch = (value: string) => {
     const searchEndpoint = `/search?name=${value}`
 
     searchItems(searchEndpoint)
+  }
+
+  const handleItemFilterChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value as ShowItem
+    setItemFilter(value)
   }
 
   const fetchItems = () => {
@@ -40,6 +46,7 @@ export const Home = (props: HomeComponentProps) => {
     })
       .then((data) => {
         setItems(data)
+        setAllItemsReference(data)
       })
       .catch((err) => {
         toast.error(err.message)
@@ -56,10 +63,28 @@ export const Home = (props: HomeComponentProps) => {
     })
       .then((data) => {
         setItems(data)
+        setAllItemsReference(data)
       })
       .catch((err) => {
         toast.error(err.message)
       })
+  }
+
+  const filterItems = (itemFilter: ShowItem, items: Item[]) => {
+    const localItems = items
+    switch (itemFilter) {
+      case "showAll":
+        setItems(localItems)
+        break
+      case "showUnsold":
+        setItems(localItems.filter((item) => item.status === 2))
+        console.log(localItems)
+        break
+      case "showSold":
+        setItems(localItems.filter((item) => item.status === 3))
+        console.log(localItems)
+        break
+    }
   }
 
   useEffect(() => {
@@ -67,22 +92,32 @@ export const Home = (props: HomeComponentProps) => {
   }, [])
 
   useEffect(() => {
+    filterItems(itemFilter, allItemsReference)
+  }, [itemFilter, allItemsReference])
+
+  useEffect(() => {
     handleSearch(props.searchValue)
   }, [props.searchValue])
-
-  const [isLogInPage, setIsLogInPage] = useState(true)
-
-
 
   const itemListPage = (
     <MerComponent>
       <div className="ItemListPage">
-        {cookies.token ||
-          cookies.userID ? <span>
-          <p>Logined User: {cookies.userName}</p>
-        </span> : null}
-        {props.searchValue ?
-          <p>Showing search results for: {props.searchValue}</p> : null}
+        {cookies.token || cookies.userID ? (
+          <span>
+            <p>Logined User: {cookies.userName}</p>
+          </span>
+        ) : null}
+        {props.searchValue ? (
+          <p>Showing search results for: {props.searchValue}</p>
+        ) : null}
+        <select
+          className="form-control ItemFilter"
+          onChange={handleItemFilterChange}
+        >
+          <option value="showAll">Show all</option>
+          <option value="showUnsold">Show Unsold Only</option>
+          <option value="showSold">Show Sold Only</option>
+        </select>
         <ItemList items={items} />
       </div>
     </MerComponent>


### PR DESCRIPTION
Changes:
Frontend

- Added a `select` button that enables users to display `all`,`sold`` or `onSale` items 
- Added a `allItemsReference` state to store a copy of all items before filtering
- Added a `itemFilter` state to keep track of the item status that the user wants to see
- Added a function `filterItems` to filter items based on the `itemFilter` state
- `filterItems` also filters when `allItemsReference` changes > Same result when users search then filter/ filter then search