### PR TITLE
Frontend: Smoothen log in & app flow

### DIFF
--- a/frontend/simple-mercari-web/src/App.css
+++ b/frontend/simple-mercari-web/src/App.css
@@ -229,6 +229,14 @@ body {
   border-color: #6d757d;
 }
 
+.HeaderLogIn {
+  width: 120px;
+}
+
+.HeaderLogIn2 {
+  width: 150px;
+}
+
 .UserProfile {
   width: 100%;
   display: flex;

--- a/frontend/simple-mercari-web/src/components/Header/Header.tsx
+++ b/frontend/simple-mercari-web/src/components/Header/Header.tsx
@@ -1,23 +1,22 @@
-import { useCookies } from "react-cookie";
-import "./Header.css";
-import { Navbar, Container, Nav, Form, FormControl, Button } from 'react-bootstrap';
-import { FaSearch } from 'react-icons/fa';
-import { AiOutlineClose } from 'react-icons/ai';
-import { useState } from "react";
-import { SearchBar } from "../SearchBar/SearchBar";
-import { useNavigate } from "react-router-dom";
-import Dropdown from 'react-bootstrap/Dropdown';
-
+import { useCookies } from "react-cookie"
+import "./Header.css"
+import { Navbar, Container, Nav } from "react-bootstrap"
+import { FaSearch } from "react-icons/fa"
+import { AiOutlineClose } from "react-icons/ai"
+import { useState } from "react"
+import { SearchBar } from "../SearchBar/SearchBar"
+import { useNavigate } from "react-router-dom"
+import { useLocation } from "react-router-dom"
+import Dropdown from "react-bootstrap/Dropdown"
 
 interface SearchBarProps {
   onSearch: (keyword: string) => void
 }
 
 export const Header = ({ onSearch }: SearchBarProps) => {
-  const [cookies, _, removeCookie] = useCookies(["userID", "userName", "token"]);
-  const [showNavbar, setShowNavbar] = useState(false);
-  const navigate = useNavigate();
-
+  const [cookies, _, removeCookie] = useCookies(["userID", "userName", "token"])
+  const [showNavbar, setShowNavbar] = useState(false)
+  const navigate = useNavigate()
 
   const onLogout = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     event.preventDefault()
@@ -29,46 +28,94 @@ export const Header = ({ onSearch }: SearchBarProps) => {
     setShowNavbar(!showNavbar)
   }
 
+  const location = useLocation()
+
+  const onHome = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    navigate("/")
+    if (location.pathname === "/") {
+      window.location.reload()
+    }
+    console.log("hello")
+  }
+
   return (
     <>
       <Navbar bg="#222427" variant="dark" expand="lg">
         <Container fluid>
           <Nav>
-            {showNavbar ? null : <Navbar.Brand className="hand-cursor" onClick={() => navigate("/")}>Simple Mercari</Navbar.Brand>}
-            <Navbar.Toggle aria-controls="responsive-navbar-nav" onClick={handleNavbarToggle}> {showNavbar ? <AiOutlineClose /> : <FaSearch />}</Navbar.Toggle>
-            <Navbar.Collapse id="responsive-navbar-nav" className={showNavbar ? 'show' : ''}>
+            {showNavbar ? null : (
+              <Navbar.Brand className="hand-cursor" onClick={onHome}>
+                Simple Mercari
+              </Navbar.Brand>
+            )}
+            <Navbar.Toggle
+              aria-controls="responsive-navbar-nav"
+              onClick={handleNavbarToggle}
+            >
+              {" "}
+              {showNavbar ? <AiOutlineClose /> : <FaSearch />}
+            </Navbar.Toggle>
+            <Navbar.Collapse
+              id="responsive-navbar-nav"
+              className={showNavbar ? "show" : ""}
+            >
               <Nav className="me-auto">
                 <SearchBar onSearch={onSearch} />
               </Nav>
             </Navbar.Collapse>
           </Nav>
-          {
-            showNavbar ? null : <Nav className="md:ml-auto">
-
-              {cookies.token ||
-                cookies.userID ? <Nav>
-
-
-                <Dropdown>
-                  <Dropdown.Toggle style={{ backgroundColor: "transparent", color: "white", borderColor: "transparent", marginRight: "10px" }} id="MerButton">
-                    Account
-                  </Dropdown.Toggle>
-
-                  <Dropdown.Menu style={{ backgroundColor: "#2D2D2D" }}>
-                    <Dropdown.Item style={{ color: "lightgray" }} onClick={() => navigate(`/user/${cookies.userID}`)}>My Page</Dropdown.Item>
-                    <Dropdown.Item style={{ color: "lightgray" }} onClick={onLogout}>Logout</Dropdown.Item>
-                  </Dropdown.Menu>
-                </Dropdown>
-                <button id="MerButton" onClick={() => navigate("/sell")}>Sell</button>
-              </Nav>
-                :
+          {showNavbar ? null : (
+            <Nav className="md:ml-auto">
+              {cookies.token || cookies.userID ? (
                 <Nav>
-                  <Nav.Link onClick={() => navigate("/login")}>Account</Nav.Link>
-                  <button id="MerButton" onClick={() => navigate("/login")}>Sell</button>
-                </Nav>}
+                  <Dropdown className="HeaderLogIn">
+                    <Dropdown.Toggle
+                      style={{
+                        backgroundColor: "transparent",
+                        color: "#6d757d",
+                        borderColor: "transparent",
+                        marginRight: "10px",
+                        padding: "2px",
+                      }}
+                      id="MerButton"
+                    >
+                      Account
+                    </Dropdown.Toggle>
 
+                    <Dropdown.Menu style={{ backgroundColor: "#2D2D2D" }}>
+                      <Dropdown.Item
+                        style={{ color: "lightgray" }}
+                        onClick={() => navigate(`/user/${cookies.userID}`)}
+                      >
+                        My Page
+                      </Dropdown.Item>
+                      <Dropdown.Item
+                        style={{ color: "lightgray" }}
+                        onClick={onLogout}
+                      >
+                        Logout
+                      </Dropdown.Item>
+                    </Dropdown.Menu>
+                  </Dropdown>
+                  <button id="MerButton" onClick={() => navigate("/sell")}>
+                    Sell
+                  </button>
+                </Nav>
+              ) : (
+                <Nav>
+                  <Nav.Link
+                    className="HeaderLogIn"
+                    onClick={() => navigate("/login")}
+                  >
+                    Log In
+                  </Nav.Link>
+                  <button id="MerButton" onClick={() => navigate("/login")}>
+                    Sell
+                  </button>
+                </Nav>
+              )}
             </Nav>
-          }
+          )}
         </Container>
       </Navbar>
     </>

--- a/frontend/simple-mercari-web/src/components/Login/Login.tsx
+++ b/frontend/simple-mercari-web/src/components/Login/Login.tsx
@@ -24,7 +24,7 @@ export const Login = () => {
       }),
     })
       .then((user) => {
-        toast.success("Signed in!")
+        toast.success(`Welcome back ${user.name}!`)
         console.log("POST success:", user.name)
         setCookie("userID", user.id)
         setCookie("userName", user.name)
@@ -40,6 +40,7 @@ export const Login = () => {
   return (
     <div>
       <div className="Login">
+        <h1>Log In</h1>
         <label id="MerInputLabel">User Name</label>
         <input
           type="text"

--- a/frontend/simple-mercari-web/src/components/SignInSignUp/SignInSignUp.tsx
+++ b/frontend/simple-mercari-web/src/components/SignInSignUp/SignInSignUp.tsx
@@ -1,50 +1,37 @@
-import React, { useEffect, useState } from 'react'
-import { Login } from '../Login/Login'
-import { Signup } from '../Signup/Signup'
-import { useCookies } from "react-cookie"
-import { useNavigate } from "react-router-dom";
+import React, { useState } from "react"
+import { Login } from "../Login/Login"
+import { Signup } from "../Signup/Signup"
 
 export const SignUpAndSignIn: React.FC = () => {
-    const [isLogInPage, setIsLogInPage] = useState(true)
-    const [cookies] = useCookies(["userID", "token"])
-    const navigate = useNavigate();
-    const toggleIsLogInPage = () => {
-        setIsLogInPage(!isLogInPage)
-    }
-    useEffect(() => {
+  const [isLogInPage, setIsLogInPage] = useState(true)
+  const toggleIsLogInPage = () => {
+    setIsLogInPage(!isLogInPage)
+  }
 
-
-        if (cookies.token &&
-            cookies.userID) {
-            navigate(`/user/${cookies.userID}`)
-        }
-
-    }, [cookies, navigate])
-
-    return (
-        <>
-            {!isLogInPage && (
-                <div>
-                    <Signup />
-                    <button
-                        className="btn btn-outline-danger button"
-                        onClick={toggleIsLogInPage}
-                    >
-                        Log In Instead
-                    </button>
-                </div>
-            )}
-            {isLogInPage && (
-                <div>
-                    <Login />
-                    <button
-                        className="btn btn-outline-danger button"
-                        onClick={toggleIsLogInPage}
-                    >
-                        Sign Up Instead
-                    </button>
-                </div>
-            )}
-        </>
-    )
+  return (
+    <>
+      {!isLogInPage && (
+        <div>
+          <Signup toggleLogIn={toggleIsLogInPage} />
+          <button
+            className="btn btn-outline-danger button"
+            onClick={toggleIsLogInPage}
+          >
+            Log In Instead
+          </button>
+        </div>
+      )}
+      {isLogInPage && (
+        <div>
+          <Login />
+          <button
+            className="btn btn-outline-danger button"
+            onClick={toggleIsLogInPage}
+          >
+            Sign Up Instead
+          </button>
+        </div>
+      )}
+    </>
+  )
 }

--- a/frontend/simple-mercari-web/src/components/Signup/Signup.tsx
+++ b/frontend/simple-mercari-web/src/components/Signup/Signup.tsx
@@ -3,7 +3,11 @@ import { useNavigate } from "react-router-dom"
 import { toast } from "react-toastify"
 import { fetcher } from "../../helper"
 
-export const Signup = () => {
+interface Props {
+  toggleLogIn: () => void
+}
+
+export const Signup: React.FC<Props> = ({ toggleLogIn }) => {
   const [name, setName] = useState<string>()
   const [password, setPassword] = useState<string>()
 
@@ -23,7 +27,7 @@ export const Signup = () => {
       .then((user) => {
         toast.success(`New account with name: ${user.name} has been created!`)
         console.log("POST success:", user.name)
-        navigate("/")
+        toggleLogIn()
       })
       .catch((err) => {
         console.log(`POST error:`, err)
@@ -34,6 +38,7 @@ export const Signup = () => {
   return (
     <div>
       <div className="Signup">
+        <h1>Sign Up</h1>
         <label id="MerInputLabel">User Name</label>
         <input
           type="text"


### PR DESCRIPTION
Changes:
Frontend:

- In `Header.tsx`, changed `account` to `log in` when user is logged out
- When user completes sign up, immediately toggle to log in page
- Added a title to sign up and log in page to make it clearer to users which page they are on
- App now reloads when user clicks `simple mercari` logo while on home page 