### PR TITLE
Frontend: UI Implementation to Edit Items (merge after #42)

### DIFF
--- a/frontend/simple-mercari-web/src/App.tsx
+++ b/frontend/simple-mercari-web/src/App.tsx
@@ -1,32 +1,55 @@
-import React, { useState } from "react";
-import { Routes, Route, BrowserRouter } from "react-router-dom";
-import { Home } from "./components/Home";
-import { ItemDetail } from "./components/ItemDetail";
-import { UserProfile } from "./components/UserProfile";
-import { Listing } from "./components/Listing";
-import "./App.css";
-import { Header } from "./components/Header/Header";
-import { ToastContainer } from 'react-toastify';
-import 'react-toastify/dist/ReactToastify.css';
-import { SignUpAndSignIn } from "./components/SignInSignUp";
+import React, { useState } from "react"
+import { Routes, Route, BrowserRouter } from "react-router-dom"
+import { Home } from "./components/Home"
+import { Item, ItemDetail } from "./components/ItemDetail"
+import { UserProfile } from "./components/UserProfile"
+import { Listing } from "./components/Listing"
+import "./App.css"
+import { Header } from "./components/Header/Header"
+import { ToastContainer } from "react-toastify"
+import "react-toastify/dist/ReactToastify.css"
+import { SignUpAndSignIn } from "./components/SignInSignUp"
 
 export const App: React.FC = () => {
   const [searchValue, setSearchValue] = useState<string>("")
   const handleSearch = (value: string) => {
     setSearchValue(value)
   }
+
+  const [itemValue, setItemValue] = useState<Item | undefined>()
+  const handleItem = (item: Item | undefined) => {
+    setItemValue(item)
+  }
+  const handleItemReset = () => {
+    setItemValue(undefined)
+  }
+
   return (
     <>
       <ToastContainer position="bottom-center" />
 
       <BrowserRouter>
         <div className="MerComponent">
-          <Header onSearch={handleSearch}></Header>
+          <Header
+            onSearch={handleSearch}
+            onResetItemState={handleItemReset}
+          ></Header>
           <Routes>
             <Route index element={<Home searchValue={searchValue} />} />
-            <Route path="/item/:id" element={<ItemDetail />} />
+            <Route
+              path="/item/:id"
+              element={<ItemDetail onUpdateItem={handleItem} />}
+            />
             <Route path="/user/:id" element={<UserProfile />} />
-            <Route path="/sell" element={<Listing />} />
+            <Route
+              path="/sell"
+              element={
+                <Listing
+                  itemValue={itemValue}
+                  onResetItemState={handleItemReset}
+                />
+              }
+            />
             <Route path="/login" element={<SignUpAndSignIn />} />
           </Routes>
         </div>

--- a/frontend/simple-mercari-web/src/components/Header/Header.tsx
+++ b/frontend/simple-mercari-web/src/components/Header/Header.tsx
@@ -11,9 +11,10 @@ import Dropdown from "react-bootstrap/Dropdown"
 
 interface SearchBarProps {
   onSearch: (keyword: string) => void
+  onResetItemState: () => void
 }
 
-export const Header = ({ onSearch }: SearchBarProps) => {
+export const Header = ({ onSearch, onResetItemState }: SearchBarProps) => {
   const [cookies, _, removeCookie] = useCookies(["userID", "userName", "token"])
   const [showNavbar, setShowNavbar] = useState(false)
   const navigate = useNavigate()
@@ -32,10 +33,20 @@ export const Header = ({ onSearch }: SearchBarProps) => {
 
   const onHome = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     navigate("/")
+    onResetItemState()
     if (location.pathname === "/") {
       window.location.reload()
     }
-    console.log("hello")
+  }
+
+  const onLoggedInSell = (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => {
+    onResetItemState()
+    navigate("/sell")
+    if (location.pathname === "/sell") {
+      window.location.reload()
+    }
   }
 
   return (
@@ -97,7 +108,7 @@ export const Header = ({ onSearch }: SearchBarProps) => {
                       </Dropdown.Item>
                     </Dropdown.Menu>
                   </Dropdown>
-                  <button id="MerButton" onClick={() => navigate("/sell")}>
+                  <button id="MerButton" onClick={onLoggedInSell}>
                     Sell
                   </button>
                 </Nav>

--- a/frontend/simple-mercari-web/src/components/Home/Home.tsx
+++ b/frontend/simple-mercari-web/src/components/Home/Home.tsx
@@ -78,11 +78,9 @@ export const Home = (props: HomeComponentProps) => {
         break
       case "showUnsold":
         setItems(localItems.filter((item) => item.status === 2))
-        console.log(localItems)
         break
       case "showSold":
         setItems(localItems.filter((item) => item.status === 3))
-        console.log(localItems)
         break
     }
   }

--- a/frontend/simple-mercari-web/src/components/ItemDetail/ItemDetail.tsx
+++ b/frontend/simple-mercari-web/src/components/ItemDetail/ItemDetail.tsx
@@ -11,7 +11,9 @@ const ItemStatus = {
   ItemStatusSoldOut: 3,
 } as const
 
-type ItemStatus = (typeof ItemStatus)[keyof typeof ItemStatus]
+type ItemStatusType = (typeof ItemStatus)[keyof typeof ItemStatus]
+
+type ButtonType = "purchase" | "sold" | "edit"
 
 interface Item {
   id: number
@@ -20,7 +22,7 @@ interface Item {
   category_name: string
   user_id: number
   price: number
-  status: ItemStatus
+  status: ItemStatusType
   description: string
 }
 
@@ -90,9 +92,25 @@ export const ItemDetail = () => {
     }
   }
 
+  const [buttonType, setButtonType] = useState<ButtonType>("purchase")
+
+  const getButtonType = (): void => {
+    if (item?.status === ItemStatus.ItemStatusSoldOut) {
+      setButtonType("sold")
+    } else if (item?.user_id.toString() === cookies.userID) {
+      setButtonType("edit")
+    } else {
+      setButtonType("purchase")
+    }
+  }
+
   useEffect(() => {
     fetchItem()
   }, [])
+
+  useEffect(() => {
+    getButtonType()
+  }, [item])
 
   return (
     <div className="ItemDetail">
@@ -110,7 +128,7 @@ export const ItemDetail = () => {
               <h3>¥ {item.price}</h3>
               <h4>Description:</h4>
               <p>{item.description}</p>
-              {item.status == ItemStatus.ItemStatusSoldOut ? (
+              {buttonType === "sold" && (
                 <button
                   disabled={true}
                   onClick={onSubmit}
@@ -118,7 +136,11 @@ export const ItemDetail = () => {
                 >
                   SoldOut
                 </button>
-              ) : (
+              )}
+              {buttonType === "edit" && (
+                <button id="MerButton">Edit Listing</button>
+              )}
+              {buttonType === "purchase" && (
                 <button onClick={onSubmit} id="MerButton">
                   Purchase
                 </button>

--- a/frontend/simple-mercari-web/src/components/ItemDetail/ItemDetail.tsx
+++ b/frontend/simple-mercari-web/src/components/ItemDetail/ItemDetail.tsx
@@ -13,9 +13,7 @@ const ItemStatus = {
 
 type ItemStatusType = (typeof ItemStatus)[keyof typeof ItemStatus]
 
-type ButtonType = "purchase" | "sold" | "edit"
-
-interface Item {
+export interface Item {
   id: number
   name: string
   category_id: number
@@ -26,7 +24,13 @@ interface Item {
   description: string
 }
 
-export const ItemDetail = () => {
+type ButtonType = "purchase" | "sold" | "edit"
+
+interface UpdateItemProps {
+  onUpdateItem: (item: Item | undefined) => void
+}
+
+export const ItemDetail = ({ onUpdateItem }: UpdateItemProps) => {
   const navigate = useNavigate()
   const params = useParams()
   const [item, setItem] = useState<Item>()
@@ -104,6 +108,11 @@ export const ItemDetail = () => {
     }
   }
 
+  const onEdit = () => {
+    onUpdateItem(item)
+    navigate("/sell")
+  }
+
   useEffect(() => {
     fetchItem()
   }, [])
@@ -138,7 +147,9 @@ export const ItemDetail = () => {
                 </button>
               )}
               {buttonType === "edit" && (
-                <button id="MerButton">Edit Listing</button>
+                <button id="MerButton" onClick={onEdit}>
+                  Edit Listing
+                </button>
               )}
               {buttonType === "purchase" && (
                 <button onClick={onSubmit} id="MerButton">


### PR DESCRIPTION
Changes:
Frontend:

- Clicking edit button on `ItemDetail` page, passes `Item` prop from `ItemDetail` page to `Listing` page
- Listings can be created or edited on `Listing` page depending on the state of `Item` prop
- Navigating away from `Listing` page while in edit mode, via logo / sell / cancel button, resets `Item` prop
<img width="1440" alt="Screenshot 2023-05-27 at 5 45 50 PM" src="https://github.com/iggyray/mercari-build-hackathon-2023/assets/128442523/dc22b9dd-c2b1-4ad2-b82a-99356cdde049">
